### PR TITLE
Improve gradle dependency graph generation performance.

### DIFF
--- a/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/DependencyNode.kt
+++ b/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/DependencyNode.kt
@@ -1,0 +1,5 @@
+package com.agoda.gradledependencytreeplugin
+
+data class DependencyNode(val id: String, val name: String) {
+    val children: MutableSet<DependencyNode> = mutableSetOf()
+}

--- a/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/GradleDependencyDiagramGeneratorPlugin.kt
+++ b/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/GradleDependencyDiagramGeneratorPlugin.kt
@@ -5,6 +5,8 @@ import org.gradle.api.Project
 
 class GradleDependencyDiagramGeneratorPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.tasks.register("generateGradleDependencyGraph", DependencyReportGenerator::class.java)
+        project.tasks.register("generateGradleDependencyGraph", DependencyReportGenerator::class.java){
+            it.group = "help"
+        }
     }
 }

--- a/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/ResolvedDependencyToDependencyNodeMapper.kt
+++ b/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/ResolvedDependencyToDependencyNodeMapper.kt
@@ -1,0 +1,9 @@
+package com.agoda.gradledependencytreeplugin
+
+import org.gradle.api.artifacts.ResolvedDependency
+
+object DependencyNodeMapper {
+    fun ResolvedDependency.mapToDependencyNode(): DependencyNode {
+        return DependencyNode(this.name, this.moduleName)
+    }
+}

--- a/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/cycledetector/CycleDetectedException.kt
+++ b/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/cycledetector/CycleDetectedException.kt
@@ -1,0 +1,3 @@
+package com.agoda.gradledependencytreeplugin.cycledetector
+
+class CycleDetectedException(message: String) : IllegalStateException(message)

--- a/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/cycledetector/CycleDetector.kt
+++ b/gradledependencytreeplugin/src/main/java/com/agoda/gradledependencytreeplugin/cycledetector/CycleDetector.kt
@@ -1,6 +1,6 @@
-package com.agoda.gradledependencytreeplugin
+package com.agoda.gradledependencytreeplugin.cycledetector
 
-import org.gradle.api.artifacts.ResolvedDependency
+import com.agoda.gradledependencytreeplugin.DependencyNode
 
 //https://en.wikipedia.org/wiki/Cycle_(graph_theory)
 //DFS(v):
@@ -13,16 +13,16 @@ import org.gradle.api.artifacts.ResolvedDependency
 //DFS(w)
 //finished(v) = true
 class CycleDetector {
-    private val visitedNode = mutableSetOf<ResolvedDependency>()
-    private val completedNodes = mutableSetOf<ResolvedDependency>()
-    fun detectCycle(resolvedDependency: ResolvedDependency) {
+    private val visitedNode = mutableSetOf<DependencyNode>()
+    private val completedNodes = mutableSetOf<DependencyNode>()
+    fun detectCycle(resolvedDependency: DependencyNode) {
         println("Checking for cycles in ${resolvedDependency.name}")
         transverseDependenciesForCycles(resolvedDependency)
     }
 
-    private fun transverseDependenciesForCycles(resolvedDependency: ResolvedDependency) {
+    private fun transverseDependenciesForCycles(resolvedDependency: DependencyNode) {
         if (completedNodes.contains(resolvedDependency)) return
-        if (visitedNode.contains(resolvedDependency)) throw IllegalStateException("Cycle detected in dependency ${resolvedDependency.name}")
+        if (visitedNode.contains(resolvedDependency)) throw CycleDetectedException("Cycle detected in dependency ${resolvedDependency.name}")
         visitedNode.add(resolvedDependency)
         resolvedDependency.children.forEach {
             transverseDependenciesForCycles(it)
@@ -30,3 +30,4 @@ class CycleDetector {
         completedNodes.add(resolvedDependency)
     }
 }
+

--- a/gradledependencytreeplugin/src/test/java/com/agoda/gradledependencytreeplugin/CycleDetectorTest.kt
+++ b/gradledependencytreeplugin/src/test/java/com/agoda/gradledependencytreeplugin/CycleDetectorTest.kt
@@ -1,0 +1,55 @@
+package com.agoda.gradledependencytreeplugin
+
+import com.agoda.gradledependencytreeplugin.cycledetector.CycleDetectedException
+import com.agoda.gradledependencytreeplugin.cycledetector.CycleDetector
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class CycleDetectorTest {
+
+    @Test
+    fun `detectCycle correctly detects cycle when a direct cycle exist`() {
+        val firstNode = DependencyNode("1", "first node")
+        val secondNode = DependencyNode("2", "second node")
+        firstNode.children.add(secondNode)
+        secondNode.children.add(firstNode)
+        assertThrows(CycleDetectedException::class.java){
+            CycleDetector().detectCycle(firstNode)
+        }
+    }
+
+    @Test
+    fun `detectCycle correctly detects cycle when indirect cycle exist`() {
+        val firstNode = DependencyNode("1", "first node")
+        val secondNode = DependencyNode("2", "second node")
+        val thirdNode = DependencyNode("3", "third node")
+        val fourthNode = DependencyNode("4", "fourth node")
+        val fifthNode = DependencyNode("5", "fifth node")
+        firstNode.children.add(secondNode)
+        secondNode.children.add(thirdNode)
+        secondNode.children.add(fourthNode)
+        fourthNode.children.add(fifthNode)
+        fifthNode.children.add(firstNode)
+        assertThrows(CycleDetectedException::class.java){
+            CycleDetector().detectCycle(firstNode)
+        }
+    }
+
+    @Test
+    fun `detectCycle does not detect cycle when a cycle does not exist`() {
+        val firstNode = DependencyNode("1", "first node")
+        val secondNode = DependencyNode("2", "second node")
+        val thirdNode = DependencyNode("3", "third node")
+        val fourthNode = DependencyNode("4", "fourth node")
+        val fifthNode = DependencyNode("5", "fifth node")
+        firstNode.children.add(secondNode)
+        secondNode.children.add(thirdNode)
+        secondNode.children.add(fourthNode)
+        fourthNode.children.add(fifthNode)
+        assertDoesNotThrow{
+            CycleDetector().detectCycle(firstNode)
+        }
+    }
+
+}


### PR DESCRIPTION
After testing for a dependency graph with a large number of dependencies, It took  a lot of time to transverse the graph before serializing, since the dependencies are immutable, we could reuse previous computation when generating new graphs. 